### PR TITLE
Add language detection method to FileEditObservation (Issue #23)

### DIFF
--- a/openhands/events/observation/files.py
+++ b/openhands/events/observation/files.py
@@ -1,5 +1,6 @@
 """File-related observation classes for tracking file operations."""
 
+import os
 from dataclasses import dataclass
 from difflib import SequenceMatcher
 
@@ -53,7 +54,7 @@ class FileEditObservation(Observation):
 
     The .content property can either be:
       - Git diff in LLM-based editing mode
-      - the rendered message sent to the LLM in OH_ACI mode (e.g., "The file /path/to/file.txt is created with the provided content.")
+      - the rendered message sent to the LMM in OH_ACI mode (e.g., "The file /path/to/file.txt is created with the provided content.")
     """
 
     path: str = ''
@@ -68,6 +69,25 @@ class FileEditObservation(Observation):
     _diff_cache: str | None = (
         None  # Cache for the diff visualization, used in LLM-based editing mode
     )
+
+    def _get_language_from_extension(self) -> str:
+        """Determine programming language from file extension."""
+        ext = os.path.splitext(self.path)[1].lower()
+        language_map = {
+            '.py': 'python',
+            '.js': 'javascript',
+            '.ts': 'typescript',
+            '.jsx': 'jsx',
+            '.tsx': 'tsx',
+            '.html': 'html',
+            '.css': 'css',
+            '.json': 'json',
+            '.md': 'markdown',
+            '.sh': 'shell',
+            '.yml': 'yaml',
+            '.yaml': 'yaml',
+        }
+        return language_map.get(ext, 'plaintext')
 
     @property
     def message(self) -> str:

--- a/tests/unit/events/observation/test_files.py
+++ b/tests/unit/events/observation/test_files.py
@@ -19,23 +19,23 @@ class TestFileObservations(unittest.TestCase):
 
     def test_file_read_observation(self):
         """Test the FileReadObservation class."""
-        obs = FileReadObservation(path='/test/file.txt')
+        obs = FileReadObservation(path='/test/file.txt', content='file content')
         self.assertEqual('I read the file /test/file.txt.', obs.message)
-        self.assertTrue(
-            str(obs).startswith('[Read from /test/file.txt is successful.\n')
+        self.assertEqual(
+            '[Read from /test/file.txt is successful.]\nfile content', str(obs)
         )
 
     def test_file_write_observation(self):
         """Test the FileWriteObservation class."""
-        obs = FileWriteObservation(path='/test/file.txt')
+        obs = FileWriteObservation(path='/test/file.txt', content='file content')
         self.assertEqual('I wrote to the file /test/file.txt.', obs.message)
-        self.assertTrue(
-            str(obs).startswith('[Write to /test/file.txt is successful.\n')
+        self.assertEqual(
+            '[Write to /test/file.txt is successful.]\nfile content', str(obs)
         )
 
     def test_file_edit_observation(self):
         """Test the FileEditObservation class."""
-        obs = FileEditObservation(path='/test/file.py')
+        obs = FileEditObservation(path='/test/file.py', content='file edit content')
         # Test basic properties
         self.assertEqual('I edited the file /test/file.py.', obs.message)
 

--- a/tests/unit/events/observation/test_files.py
+++ b/tests/unit/events/observation/test_files.py
@@ -1,0 +1,65 @@
+"""Tests for file observation classes."""
+
+import os
+import sys
+import unittest
+
+# Add the project root directory to the Python path
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../../..')))
+
+from openhands.events.observation.files import (
+    FileEditObservation,
+    FileReadObservation,
+    FileWriteObservation,
+)
+
+
+class TestFileObservations(unittest.TestCase):
+    """Test the file observation classes."""
+
+    def test_file_read_observation(self):
+        """Test the FileReadObservation class."""
+        obs = FileReadObservation(path='/test/file.txt')
+        self.assertEqual('I read the file /test/file.txt.', obs.message)
+        self.assertTrue(
+            str(obs).startswith('[Read from /test/file.txt is successful.\n')
+        )
+
+    def test_file_write_observation(self):
+        """Test the FileWriteObservation class."""
+        obs = FileWriteObservation(path='/test/file.txt')
+        self.assertEqual('I wrote to the file /test/file.txt.', obs.message)
+        self.assertTrue(
+            str(obs).startswith('[Write to /test/file.txt is successful.\n')
+        )
+
+    def test_file_edit_observation(self):
+        """Test the FileEditObservation class."""
+        obs = FileEditObservation(path='/test/file.py')
+        # Test basic properties
+        self.assertEqual('I edited the file /test/file.py.', obs.message)
+
+        # Test _get_language_from_extension method
+        self.assertEqual('python', obs._get_language_from_extension())
+
+        # Test with different extensions
+        obs.path = '/test/file.js'
+        self.assertEqual('javascript', obs._get_language_from_extension())
+
+        obs.path = '/test/file.tsx'
+        self.assertEqual('tsx', obs._get_language_from_extension())
+
+        obs.path = '/test/file.md'
+        self.assertEqual('markdown', obs._get_language_from_extension())
+
+        # Test with unknown extension
+        obs.path = '/test/file.unknown'
+        self.assertEqual('plaintext', obs._get_language_from_extension())
+
+        # Test case insensitivity
+        obs.path = '/test/file.PY'
+        self.assertEqual('python', obs._get_language_from_extension())
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION

This PR adds a new `_get_language_from_extension` method to the `FileEditObservation` class as requested in Issue #23.

The implementation:
1. Extracts file extension from the path
2. Maps common extensions to programming languages
3. Returns "plaintext" for unknown extensions
4. Is case-insensitive

Supported extensions include: .py, .js, .ts, .jsx, .tsx, .html, .css, .json, .md, .sh, .yml, .yaml

I've also added unit tests to verify the functionality.

This change is part of the LLM Editor Diff Visualization Enhancement project.
