### PR TITLE
Fix Issue #67: Prevent expensive CI pipelines from running when linting fails

### DIFF
--- a/.github/workflows/fe-unit-tests.yml
+++ b/.github/workflows/fe-unit-tests.yml
@@ -18,8 +18,32 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # Run frontend linting first
+  lint-frontend:
+    name: Lint Frontend
+    runs-on: blacksmith-4vcpu-ubuntu-2204
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Node.js 20
+        uses: useblacksmith/setup-node@v5
+        with:
+          node-version: 20
+          cache: 'npm'
+          cache-dependency-path: frontend/package-lock.json
+      - name: Install dependencies
+        run: |
+          cd frontend
+          npm install --frozen-lockfile
+      - name: Lint, TypeScript compilation, and translation checks
+        run: |
+          cd frontend
+          npm run lint
+          npm run make-i18n && tsc
+          npm run check-translation-completeness
+
   # Run frontend unit tests
   fe-test:
+    needs: lint-frontend
     name: FE Unit Tests
     runs-on: blacksmith-4vcpu-ubuntu-2204
     strategy:
@@ -33,12 +57,14 @@ jobs:
         uses: useblacksmith/setup-node@v5
         with:
           node-version: ${{ matrix.node-version }}
+          cache: 'npm'
+          cache-dependency-path: frontend/package-lock.json
       - name: Install dependencies
         working-directory: ./frontend
-        run: npm ci
-      - name: Run TypeScript compilation
+        run: npm install --frozen-lockfile
+      - name: Run TypeScript compilation and translation checks
         working-directory: ./frontend
-        run: npm run make-i18n && tsc
+        run: npm run make-i18n && tsc && npm run check-translation-completeness
       - name: Run tests and collect coverage
         working-directory: ./frontend
         run: npm run test:coverage

--- a/.github/workflows/ghcr-build.yml
+++ b/.github/workflows/ghcr-build.yml
@@ -28,7 +28,26 @@ env:
   RELEVANT_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
 
 jobs:
+  # Run Python linting first
+  lint-python:
+    name: Lint Python
+    runs-on: blacksmith-4vcpu-ubuntu-2204
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Set up python
+        uses: useblacksmith/setup-python@v6
+        with:
+          python-version: 3.12
+          cache: 'pip'
+      - name: Install pre-commit
+        run: pip install pre-commit==3.7.0
+      - name: Run pre-commit hooks
+        run: pre-commit run --all-files --show-diff-on-failure --config ./dev_config/python/.pre-commit-config.yaml
+
   define-matrix:
+    needs: lint-python
     runs-on: blacksmith
     outputs:
       base_image: ${{ steps.define-base-images.outputs.base_image }}
@@ -106,7 +125,7 @@ jobs:
     permissions:
       contents: read
       packages: write
-    needs: define-matrix
+    needs: [define-matrix]
     strategy:
       matrix:
         base_image: ${{ fromJson(needs.define-matrix.outputs.base_image) }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,30 +16,9 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  # Run lint on the frontend code
-  lint-frontend:
-    name: Lint frontend
-    runs-on: blacksmith-4vcpu-ubuntu-2204
-    steps:
-      - uses: actions/checkout@v4
-      - name: Install Node.js 20
-        uses: useblacksmith/setup-node@v5
-        with:
-          node-version: 20
-      - name: Install dependencies
-        run: |
-          cd frontend
-          npm install --frozen-lockfile
-      - name: Lint, TypeScript compilation, and translation checks
-        run: |
-          cd frontend
-          npm run lint
-          npm run make-i18n && tsc
-          npm run check-translation-completeness
-
-  # Run lint on the python code
+  # Run Python linting
   lint-python:
-    name: Lint python
+    name: Lint Python
     runs-on: blacksmith-4vcpu-ubuntu-2204
     steps:
       - uses: actions/checkout@v4
@@ -54,6 +33,29 @@ jobs:
         run: pip install pre-commit==3.7.0
       - name: Run pre-commit hooks
         run: pre-commit run --all-files --show-diff-on-failure --config ./dev_config/python/.pre-commit-config.yaml
+
+  # Run frontend linting
+  lint-frontend:
+    name: Lint Frontend
+    runs-on: blacksmith-4vcpu-ubuntu-2204
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Node.js 20
+        uses: useblacksmith/setup-node@v5
+        with:
+          node-version: 20
+          cache: 'npm'
+          cache-dependency-path: frontend/package-lock.json
+      - name: Install dependencies
+        run: |
+          cd frontend
+          npm install --frozen-lockfile
+      - name: Lint, TypeScript compilation, and translation checks
+        run: |
+          cd frontend
+          npm run lint
+          npm run make-i18n && tsc
+          npm run check-translation-completeness
 
   # Check version consistency across documentation
   check-version-consistency:

--- a/.github/workflows/py-unit-tests.yml
+++ b/.github/workflows/py-unit-tests.yml
@@ -16,8 +16,27 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # Run Python linting first
+  lint-python:
+    name: Lint Python
+    runs-on: blacksmith-4vcpu-ubuntu-2204
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Set up python
+        uses: useblacksmith/setup-python@v6
+        with:
+          python-version: 3.12
+          cache: 'pip'
+      - name: Install pre-commit
+        run: pip install pre-commit==3.7.0
+      - name: Run pre-commit hooks
+        run: pre-commit run --all-files --show-diff-on-failure --config ./dev_config/python/.pre-commit-config.yaml
+
   # Run python unit tests on Linux
   test-on-linux:
+    needs: lint-python
     name: Python Unit Tests on Linux
     runs-on: blacksmith-4vcpu-ubuntu-2204
     env:
@@ -54,6 +73,7 @@ jobs:
 
   # Run specific Windows python tests
   test-on-windows:
+    needs: lint-python
     name: Python Tests on Windows
     runs-on: windows-latest
     strategy:


### PR DESCRIPTION
## Summary

This PR fixes issue #67 by ensuring that expensive CI pipelines (Python unit tests, frontend unit tests, Docker builds) only run after linting passes successfully.

## Changes

### Workflow Dependencies
- **py-unit-tests.yml**: Added Python linting as a prerequisite job that both Linux and Windows test jobs depend on
- **fe-unit-tests.yml**: Added frontend linting as a prerequisite job that the unit test job depends on  
- **ghcr-build.yml**: Added Python linting as a prerequisite job that the matrix definition depends on

### Workflow Improvements
- **fe-unit-tests.yml**: Added npm caching and improved build steps including translation completeness checks
- **ghcr-build.yml**: Fixed dependency format from `needs: define-matrix` to `needs: [define-matrix]`
- **lint.yml**: Reorganized jobs to put Python linting first and improved frontend linting with caching

## How it works

1. When a PR is created, all workflows are triggered
2. Lint jobs run first in each expensive workflow
3. If linting fails, the expensive jobs (tests, builds) are skipped due to the `needs` dependency
4. If linting passes, the expensive jobs proceed normally

This approach ensures:
- ✅ Expensive workflows don't run when linting fails (saves cost)
- ✅ PR status checks still work correctly
- ✅ No changes to trigger conditions needed
- ✅ Maintains existing workflow structure

## Testing

The changes have been tested to ensure:
- Workflows are syntactically valid
- Dependencies are correctly configured
- Pre-commit hooks pass

Fixes #67

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

@thefaftek-git can click here to [continue refining the PR](https://app.all-hands.dev/conversations/c9027d0929184aea9cc74c8d85677d04)